### PR TITLE
fix test error caused by GC timing problem

### DIFF
--- a/spec/clang/index_spec.rb
+++ b/spec/clang/index_spec.rb
@@ -32,7 +32,7 @@ describe Index do
 	let(:index) { Index.new }
 
 	it "calls dispose_index_debug_unit on GC" do
-		expect(Lib).to receive(:dispose_index).with(index)
+		expect(Lib).to receive(:dispose_index).with(index).at_least(:once)
 		expect{index.free}.not_to raise_error
 	end
 


### PR DESCRIPTION
Fix previous error. It is GC timing problem. Methods to release AutoPointer are called some times at the same time.
