### PR TITLE
add Cursor#kind_spelling that returns the spelling of cursor kind

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -35,6 +35,11 @@ module FFI
 				Cursor.new Lib.get_null_cursor, nil
 			end
 
+			# this function is categorized as "Debugging facilities"
+			def self.kind_spelling(kind)
+				Lib.extract_string Lib.get_cursor_kind_spelling(kind)
+			end
+
 			def initialize(cxcursor, translation_unit)
 				@cursor = cxcursor
 				@translation_unit = translation_unit
@@ -126,6 +131,10 @@ module FFI
 
 			def kind
 				@cursor[:kind]
+			end
+
+			def kind_spelling
+				Cursor.kind_spelling @cursor[:kind]
 			end
 
 			def type

--- a/lib/ffi/clang/lib/cursor.rb
+++ b/lib/ffi/clang/lib/cursor.rb
@@ -296,6 +296,7 @@ module FFI
 			attach_function :get_cursor_display_name, :clang_getCursorDisplayName, [CXCursor.by_value], CXString.by_value
 			attach_function :get_cursor_spelling, :clang_getCursorSpelling, [CXCursor.by_value], CXString.by_value
 			attach_function :get_cursor_usr, :clang_getCursorUSR, [CXCursor.by_value], CXString.by_value
+			attach_function :get_cursor_kind_spelling, :clang_getCursorKindSpelling, [:kind], CXString.by_value
 
 			attach_function :are_equal, :clang_equalCursors, [CXCursor.by_value, CXCursor.by_value], :uint
 

--- a/spec/clang/cursor_spec.rb
+++ b/spec/clang/cursor_spec.rb
@@ -144,6 +144,14 @@ describe Cursor do
 
 	end
 
+	describe '#kind_spelling' do
+		let (:struct) { find_first(cursor, :cursor_struct) }
+
+		it "returns the spelling of the given kind" do
+			expect(struct.kind_spelling).to eq('StructDecl')
+		end
+	end
+
 	describe '#declaration?' do
 		let (:struct) { find_first(cursor, :cursor_struct) }
 


### PR DESCRIPTION
This is a [Debugging facilities](http://clang.llvm.org/doxygen/group__CINDEX__DEBUG.html) function.
