### PR TITLE
add Token class

### DIFF
--- a/lib/ffi/clang.rb
+++ b/lib/ffi/clang.rb
@@ -51,4 +51,4 @@ require 'ffi/clang/cursor'
 require 'ffi/clang/source_location'
 require 'ffi/clang/source_range'
 require 'ffi/clang/unsaved_file'
-
+require 'ffi/clang/token'

--- a/lib/ffi/clang/lib/token.rb
+++ b/lib/ffi/clang/lib/token.rb
@@ -1,0 +1,58 @@
+# Copyright, 2014, by Masahiro Sano.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+module FFI
+	module Clang
+		module Lib
+			class CXToken < FFI::Struct
+				layout(
+					:int_data, [:uint, 4],
+					:ptr_data, :pointer,
+				)
+			end
+
+			class TokensPointer < FFI::Pointer
+				attr_reader :token_size
+				attr_reader :translation_unit
+				def initialize(ptr, token_size, translation_unit)
+					super ptr
+					@token_size = token_size
+					@translation_unit = translation_unit
+				end
+			end
+
+			enum :token_kind, [
+				:punctuation,
+				:keyword,
+				:identifier,
+				:literal,
+				:comment,
+			]
+
+			attach_function :get_token_kind, :clang_getTokenKind, [CXToken.by_value], :token_kind
+			attach_function :get_token_spelliing, :clang_getTokenSpelling, [:CXTranslationUnit, CXToken.by_value], CXString.by_value
+			attach_function :get_token_location, :clang_getTokenLocation, [:CXTranslationUnit, CXToken.by_value], CXSourceLocation.by_value
+			attach_function :get_token_extent, :clang_getTokenExtent, [:CXTranslationUnit, CXToken.by_value], CXSourceRange.by_value
+			attach_function :tokenize, :clang_tokenize, [:CXTranslationUnit, CXSourceRange.by_value, :pointer, :pointer], :void
+			attach_function :annotate_tokens, :clang_annotateTokens, [:CXTranslationUnit, :pointer, :uint, :pointer], :void
+			attach_function :dispose_tokens, :clang_disposeTokens, [:CXTranslationUnit, :pointer, :uint], :void
+		end
+	end
+end

--- a/lib/ffi/clang/token.rb
+++ b/lib/ffi/clang/token.rb
@@ -1,0 +1,95 @@
+# Copyright, 2014, by Masahiro Sano.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'ffi/clang/lib/token'
+require 'ffi/clang/lib/cursor'
+require 'ffi/clang/source_location'
+
+module FFI
+	module Clang
+		class Tokens < AutoPointer
+			include Enumerable
+
+			attr_reader :size
+			attr_reader :tokens
+
+			def initialize(pointer, token_size, translation_unit)
+				ptr = Lib::TokensPointer.new(pointer,token_size, translation_unit)
+				super ptr
+
+				@translation_unit = translation_unit
+				@size = token_size
+
+				@tokens = []
+				cur_ptr = pointer
+				token_size.times {
+					@tokens << Token.new(cur_ptr, translation_unit)
+					cur_ptr += Lib::CXToken.size
+				}
+			end
+
+			def self.release(pointer)
+				Lib.dispose_tokens(pointer, pointer.token_size, pointer.translation_unit)
+			end
+
+			def each(&block)
+				@tokens.each do |token|
+					block.call(token)
+				end
+			end
+
+			def cursors
+				ptr = MemoryPointer.new(Lib::CXCursor, @size)
+				Lib.annotate_tokens(@translation_unit, self, @size, ptr)
+
+				cur_ptr = ptr
+				arr = []
+				@size.times {
+					arr << Cursor.new(cur_ptr, @translation_unit)
+					cur_ptr += Lib::CXCursor.size
+				}
+				arr
+			end
+		end
+
+		class Token
+			def initialize(token, translation_unit)
+				@token = token
+				@translation_unit = translation_unit
+			end
+
+			def kind
+				Lib.get_token_kind(@token)
+			end
+
+			def spelling
+				Lib.extract_string Lib.get_token_spelliing(@translation_unit, @token)
+			end
+
+			def location
+				ExpansionLocation.new Lib.get_token_location(@translation_unit, @token)
+			end
+
+			def extent
+				SourceRange.new Lib.get_token_extent(@translation_unit, @token)
+			end
+		end
+	end
+end

--- a/lib/ffi/clang/translation_unit.rb
+++ b/lib/ffi/clang/translation_unit.rb
@@ -23,6 +23,7 @@
 require 'ffi/clang/lib/translation_unit'
 require 'ffi/clang/cursor'
 require 'ffi/clang/file'
+require 'ffi/clang/token'
 
 module FFI
 	module Clang
@@ -99,6 +100,13 @@ module FFI
 
 			def resource_usage
 				FFI::Clang::TranslationUnit::ResourceUsage.new Lib.resource_usage(self)
+			end
+
+			def tokenize(range)
+				token_ptr = MemoryPointer.new :pointer
+				uint_ptr = MemoryPointer.new :uint
+				Lib.tokenize(self, range.range, token_ptr, uint_ptr)
+				Tokens.new(token_ptr.get_pointer(0), uint_ptr.get_uint(0), self)
 			end
 
 			class ResourceUsage < AutoPointer

--- a/spec/clang/token_spec.rb
+++ b/spec/clang/token_spec.rb
@@ -1,0 +1,83 @@
+# Copyright, 2014, by Masahiro Sano.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'spec_helper'
+
+describe Tokens do
+	let(:tu) { Index.new.parse_translation_unit(fixture_path("list.c")) }
+	let(:cursor) { tu.cursor }
+	let(:range) { find_first(cursor, :cursor_struct).extent }
+	let(:tokens) { tu.tokenize(range) }
+
+	it "can be obtained from a translation unit" do
+		expect(tokens).to be_kind_of(Tokens)
+		expect(tokens.size).to eq(13)
+		expect(tokens.tokens).to be_kind_of(Array)
+		expect(tokens.tokens.first).to be_kind_of(Token)
+	end
+
+	it "calls dispose_tokens on GC" do
+		expect(Lib).to receive(:dispose_tokens).at_least(:once)
+		expect{tokens.free}.not_to raise_error
+	end
+
+	it "#each" do
+		spy = double(stub: nil)
+		expect(spy).to receive(:stub).exactly(tokens.size).times
+		tokens.each { spy.stub }
+	end
+
+	it "#cursors" do
+		expect(tokens.cursors).to be_kind_of(Array)
+		expect(tokens.cursors.size).to eq(tokens.size)
+		expect(tokens.cursors.first).to be_kind_of(Cursor)
+	end
+end
+
+describe Token do
+	let(:tu) { Index.new.parse_translation_unit(fixture_path("list.c")) }
+	let(:cursor) { tu.cursor }
+	let(:range) { find_first(cursor, :cursor_struct).extent }
+	let(:token) { tu.tokenize(range).first }
+
+	it "can be obtained from a translation unit" do
+		expect(token).to be_kind_of(Token)
+	end
+
+	it "#kind" do
+		expect(token.kind).to be_kind_of(Symbol)
+		expect(token.kind).to eq(:keyword)
+	end
+
+	it "#spelling" do
+		expect(token.spelling).to be_kind_of(String)
+		expect(token.spelling).to eq('struct')
+	end
+
+	it "#location" do
+		expect(token.location).to be_kind_of(SourceLocation)
+		expect(token.location.line).to eq(1)
+	end
+
+	it "#extent" do
+		expect(token.extent).to be_kind_of(SourceRange)
+		expect(token.extent.start.line).to eq(1)
+	end
+end


### PR DESCRIPTION
Add all functions of [Token class](http://clang.llvm.org/doxygen/group__CINDEX__LEX.html).

`clang_tokenize` returns tokens as array by pointer and it should be disposed  as is. `Tokens` is a class which is responsible for disposing returned pointer. It inherits Enumerable, so it can be used like Array of Token.
