### PR TITLE
change the version parser to handle Apple's clang as well

### DIFF
--- a/lib/ffi/clang/utils.rb
+++ b/lib/ffi/clang/utils.rb
@@ -30,7 +30,7 @@ module FFI
 
 			def self.clang_version
 				version = clang_version_string
-				version.match(/clang version (\d+\.\d+)/).values_at(1).first
+				version.match(/based on LLVM (\d+\.\d+)/).values_at(1).first
 			end
 
 			def self.clang_version_symbol
@@ -40,12 +40,12 @@ module FFI
 
 			def self.clang_major_version
 				version = clang_version_string
-				version.match(/clang version (\d+)\./).values_at(1).first.to_i
+				version.match(/based on LLVM (\d+)\./).values_at(1).first.to_i
 			end
 
 			def self.clang_minor_version
 				version = clang_version_string
-				version.match(/clang version \d+\.(\d+)/).values_at(1).first.to_i
+				version.match(/based on LLVM \d+\.(\d+)/).values_at(1).first.to_i
 			end
 
 			def self.satisfy_version?(min_version, max_version = nil)


### PR DESCRIPTION
The version string from Apple's version of clang looks like this: `Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)`

The string on Ubuntu looks like this: `Ubuntu clang version 3.0-6ubuntu3 (tags/RELEASE_30/final) (based on LLVM 3.0)`

So, it seems "based on LLVM x.y" is more reliable than "clang version x.y", at least in the cases I can find. Perhaps there are more, and this has to be more complicated?
