### PR TITLE
Allow setting the libclang path verbatim

### DIFF
--- a/lib/ffi/clang/lib.rb
+++ b/lib/ffi/clang/lib.rb
@@ -26,7 +26,9 @@ module FFI
 
 			libs = ["clang"]
 
-			if ENV['LLVM_CONFIG']
+			if ENV['LIBCLANG']
+				libs << ENV['LIBCLANG']
+			elsif ENV['LLVM_CONFIG']
 				llvm_library_dir = `#{ENV['LLVM_CONFIG']} --libdir`.chomp
 
 				libs << llvm_library_dir + '/libclang.dylib'


### PR DESCRIPTION
On OS X there is no `llvm-config`. Allow the user to pass in the full path, which it's up to them to find.

(on my machine it's `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib` )
