### PR TITLE
catch FFI::NotFoundError and ignore

### DIFF
--- a/lib/ffi/clang/lib/cursor.rb
+++ b/lib/ffi/clang/lib/cursor.rb
@@ -331,8 +331,14 @@ module FFI
 			attach_function :get_cursor_hash, :clang_hashCursor, [CXCursor.by_value], :uint
 
 			if FFI::Clang::Utils.satisfy_version?('3.3')
-				attach_function :is_bit_field,:clang_Cursor_isBitField, [CXCursor.by_value], :uint
-				attach_function :get_field_decl_bit_width, :clang_getFieldDeclBitWidth, [CXCursor.by_value], :int
+				begin
+					attach_function :is_bit_field,:clang_Cursor_isBitField, [CXCursor.by_value], :uint
+				rescue FFI::NotFoundError => e
+				end
+				begin
+					attach_function :get_field_decl_bit_width, :clang_getFieldDeclBitWidth, [CXCursor.by_value], :int
+				rescue FFI::NotFoundError => e
+				end
 			end
 
 			attach_function :get_overloaded_decl, :clang_getOverloadedDecl, [CXCursor.by_value, :uint], CXCursor.by_value

--- a/lib/ffi/clang/lib/type.rb
+++ b/lib/ffi/clang/lib/type.rb
@@ -138,9 +138,18 @@ module FFI
 			attach_function :get_array_element_type ,:clang_getArrayElementType, [CXType.by_value], CXType.by_value
 
 			if FFI::Clang::Utils.satisfy_version?('3.3')
-				attach_function :type_get_align_of, :clang_Type_getAlignOf, [CXType.by_value], :long_long
-				attach_function :type_get_size_of, :clang_Type_getSizeOf, [CXType.by_value], :long_long
-				attach_function :type_get_offset_of, :clang_Type_getOffsetOf, [CXType.by_value, :string], :long_long
+				begin
+					attach_function :type_get_align_of, :clang_Type_getAlignOf, [CXType.by_value], :long_long
+				rescue FFI::NotFoundError => e
+				end
+				begin
+					attach_function :type_get_size_of, :clang_Type_getSizeOf, [CXType.by_value], :long_long
+				rescue FFI::NotFoundError => e
+				end
+				begin
+					attach_function :type_get_offset_of, :clang_Type_getOffsetOf, [CXType.by_value, :string], :long_long
+				rescue FFI::NotFoundError => e
+				end
 			end
 
 			if FFI::Clang::Utils.satisfy_version?('3.4')


### PR DESCRIPTION
Related to #21

Presumably since the LLVM Apple specifics is "3.3svn" instead of "3.3", a few functions are not present in my version of libclang. This somewhat hacky commit just ignore the NotFoundError and continues.
