### PR TITLE
avoid possible double free error on tests by setting autorelease off

### DIFF
--- a/spec/clang/diagnostic_spec.rb
+++ b/spec/clang/diagnostic_spec.rb
@@ -30,7 +30,8 @@ describe Diagnostic do
 	end
 
 	it "calls dispose_diagnostic on GC" do
-		expect(Lib).to receive(:dispose_diagnostic).with(diagnostic).at_least(:once)
+		diagnostic.autorelease = false
+		expect(Lib).to receive(:dispose_diagnostic).with(diagnostic).once
 		expect{diagnostic.free}.not_to raise_error
 	end
 

--- a/spec/clang/index_spec.rb
+++ b/spec/clang/index_spec.rb
@@ -32,7 +32,8 @@ describe Index do
 	let(:index) { Index.new }
 
 	it "calls dispose_index_debug_unit on GC" do
-		expect(Lib).to receive(:dispose_index).with(index).at_least(:once)
+		index.autorelease = false
+		expect(Lib).to receive(:dispose_index).with(index).once
 		expect{index.free}.not_to raise_error
 	end
 

--- a/spec/clang/token_spec.rb
+++ b/spec/clang/token_spec.rb
@@ -34,6 +34,7 @@ describe Tokens do
 	end
 
 	it "calls dispose_tokens on GC" do
+		tokens.autorelease = false
 		expect(Lib).to receive(:dispose_tokens).at_least(:once)
 		expect{tokens.free}.not_to raise_error
 	end

--- a/spec/clang/translation_unit_spec.rb
+++ b/spec/clang/translation_unit_spec.rb
@@ -46,7 +46,8 @@ describe TranslationUnit do
 	end
 
 	it "calls dispose_translation_unit on GC" do
-		expect(Lib).to receive(:dispose_translation_unit).with(tu)
+		tu.autorelease = false
+		expect(Lib).to receive(:dispose_translation_unit).with(tu).once
 		expect{tu.free}.not_to raise_error
 	end
 
@@ -207,6 +208,7 @@ describe TranslationUnit do
 
 		describe "#self.release" do
 			it "releases data by calling 'clang_disposeCXTUResourceUsage'" do
+				ru.autorelease = false
 				expect{ ru.free }.not_to raise_error
 			end
 		end


### PR DESCRIPTION
`free` method is used explicitly to immediately call dispose method for test because sometimes tests finished before GC. This will fix double free in the test cases.
