### PR TITLE
Only use dylib on Darwin

### DIFF
--- a/lib/ffi/clang/lib.rb
+++ b/lib/ffi/clang/lib.rb
@@ -31,7 +31,11 @@ module FFI
 			elsif ENV['LLVM_CONFIG']
 				llvm_library_dir = `#{ENV['LLVM_CONFIG']} --libdir`.chomp
 
-				libs << llvm_library_dir + '/libclang.dylib'
+				if FFI::Clang.platform == :darwin
+					libs << llvm_library_dir + '/libclang.dylib'
+				else
+					libs << llvm_library_dir + '/libclang.so'
+				end
 			end
 
 			ffi_lib libs


### PR DESCRIPTION
Elsewhere, let's use the '.so' suffix as it's the one used by the other
unices.
