### PR TITLE
Merge (at least) lib/ffi/clang/utils.rb to recognize newer Apple's clang versions

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -158,6 +158,10 @@ module FFI
 				Type.new Lib.get_enum_decl_integer_type(@cursor), @translation_unit
 			end
 
+			def typedef_type
+				Type.new Lib.get_typedef_decl_unerlying_type(@cursor), @translation_unit
+			end
+
 			def virtual_base?
 				Lib.is_virtual_base(@cursor) != 0
 			end
@@ -192,6 +196,10 @@ module FFI
 
 			def enum_unsigned_value
 				Lib.get_enum_unsigned_value @cursor
+			end
+
+			def enum_type
+				Type.new Lib.get_enum_type(@cursor), @translation_unit
 			end
 
 			def specialized_template
@@ -232,6 +240,14 @@ module FFI
 
 			def translation_unit
 				@translation_unit
+			end
+
+			def num_args
+				Lib.get_num_args @cursor
+			end
+
+			def variadic?
+				Lib.is_variadic(@cursor) != 0
 			end
 
 			def visit_children(&block)

--- a/lib/ffi/clang/lib.rb
+++ b/lib/ffi/clang/lib.rb
@@ -24,7 +24,15 @@ module FFI
 		module Lib
 			extend FFI::Library
 
-			libs = ["clang"]
+			libs = []
+			begin
+				xcode_dir = `xcode-select -p`.chomp
+				libs << "#{xcode_dir}/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib"
+			rescue Errno::ENOENT => e
+				# Ignore
+			end
+
+			libs << "clang"
 
 			if ENV['LIBCLANG']
 				libs << ENV['LIBCLANG']

--- a/lib/ffi/clang/lib/cursor.rb
+++ b/lib/ffi/clang/lib/cursor.rb
@@ -348,6 +348,15 @@ module FFI
 
 			attach_function :get_overridden_cursors, :clang_getOverriddenCursors, [CXCursor.by_value, :pointer, :pointer], :void
 			attach_function :dispose_overridden_cursors, :clang_disposeOverriddenCursors, [:pointer], :void
+
+			attach_function :get_typedef_decl_unerlying_type, :clang_getTypedefDeclUnderlyingType, [CXCursor.by_value], CXType.by_value
+			attach_function :get_type_declaration, :clang_getTypeDeclaration, [CXType.by_value], CXCursor.by_value
+
+			attach_function :get_enum_type, :clang_getEnumDeclIntegerType, [CXCursor.by_value], CXType.by_value
+
+			attach_function :get_num_args, :clang_Cursor_getNumArguments, [CXCursor.by_value], :int
+
+			attach_function :is_variadic, :clang_Cursor_isVariadic, [CXCursor.by_value], :uint
 		end
 	end
 end

--- a/lib/ffi/clang/lib/type.rb
+++ b/lib/ffi/clang/lib/type.rb
@@ -149,6 +149,9 @@ module FFI
 			attach_function :get_fuction_type_calling_conv, :clang_getFunctionTypeCallingConv, [CXType.by_value], :calling_conv
 
 			attach_function :equal_types, :clang_equalTypes, [CXType.by_value, CXType.by_value], :uint
+
+			attach_function :get_array_element_type, :clang_getArrayElementType, [CXType.by_value], CXType.by_value
+			attach_function :get_array_size, :clang_getArraySize, [CXType.by_value], :int
 		end
 	end
 end

--- a/lib/ffi/clang/type.rb
+++ b/lib/ffi/clang/type.rb
@@ -130,6 +130,18 @@ module FFI
 			def ==(other)
 				Lib.equal_types(@type, other.type) != 0
 			end
+
+			def declaration
+				Cursor.new Lib.get_type_declaration(@type), @translation_unit
+			end
+
+			def element_type
+				Type.new Lib.get_array_element_type(@type), @translation_unit
+			end
+
+			def array_size
+				Lib.get_array_size(@type)
+			end
 		end
 	end
 end

--- a/lib/ffi/clang/utils.rb
+++ b/lib/ffi/clang/utils.rb
@@ -35,10 +35,14 @@ module FFI
 				unless @@clang_version
 					# Version string vary wildy:
 					# Ubuntu: "Ubuntu clang version 3.0-6ubuntu3 (tags/RELEASE_30/final) (based on LLVM 3.0)"
-					# Mac OS X: "Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)"
+					# Mac OS X: "Apple LLVM version 7.0.0 (clang-700.0.72)"
 					# Linux: "clang version 3.3"
-				
-					if parts = clang_version_string.match(/(?:clang version|based on LLVM) (\d+)\.(\d+)(svn)?/)
+					if parts = clang_version_string.match(/^Apple LLVM version (\d+)\.(\d+).\d \(clang-.*\)$/)
+						@@clang_version = [3, 7] # Fake it.
+
+						puts "Using libclang: #{Lib::ffi_libraries[0].name}"
+						puts "Clang version detected: #{@@clang_version.inspect}"
+					elsif parts = clang_version_string.match(/(?:clang version|based on LLVM) (\d+)\.(\d+)(svn)?/)
 						major = parts[1].to_i
 						minor = parts[2].to_i
 						rc = parts[3]

--- a/lib/ffi/clang/utils.rb
+++ b/lib/ffi/clang/utils.rb
@@ -50,6 +50,7 @@ module FFI
 					
 						@@clang_version = [major, minor]
 						
+						puts "Using libclang: #{Lib::ffi_libraries[0].name}"
 						puts "Clang version detected: #{@@clang_version.inspect}"
 					else
 						abort "Invalid/unsupported clang version string."


### PR DESCRIPTION
Hi all,

I don't know about the other changes made in this fork, but it would be great to merge at least the utils.rb to recognize the newer versions of Apple's clang (>= 7).

Thank you very much in advance