### PR TITLE
Add missing translation unit parse flags

### DIFF
--- a/lib/ffi/clang/lib.rb
+++ b/lib/ffi/clang/lib.rb
@@ -61,9 +61,7 @@ module FFI
 			def self.bitmask_from(enum, opts)
 				bitmask = 0
 
-				opts.each do |key, val|
-					next unless val
-
+				opts.each do |key, value|
 					if int = enum[key]
 						bitmask |= int
 					else

--- a/lib/ffi/clang/lib/translation_unit.rb
+++ b/lib/ffi/clang/lib/translation_unit.rb
@@ -37,6 +37,12 @@ module FFI
 				:cxx_chained_pch, 0x20,
 				:skip_function_bodies, 0x40,
 				:include_brief_comments_in_code_completion, 0x80,
+				:create_preamble_on_first_parse, 0x100,
+				:keep_going, 0x200,
+				:single_file_parse, 0x400,
+				:limit_skip_function_bodies_to_preamble, 0x800,
+				:include_attributed_type, 0x1000,
+				:visit_implicit_attributes, 0x2000
 			]
 
 			SaveTranslationUnitFlags = enum [

--- a/spec/ffi/clang/index_spec.rb
+++ b/spec/ffi/clang/index_spec.rb
@@ -49,6 +49,22 @@ describe Index do
 		it "can handle command line options" do
 			expect{index.parse_translation_unit(fixture_path("a.c"), ["-std=c++11"])}.not_to raise_error
 		end
+
+		it 'can handle translation unit options' do 
+			expect{index.parse_translation_unit(fixture_path("a.c"), [], [], [:incomplete, :single_file_parse, :cache_completion_results])}.not_to raise_error
+		end
+
+		it 'can handle missing translation options' do 
+			expect{index.parse_translation_unit(fixture_path("a.c"), [], [], [])}.not_to raise_error
+		end
+
+		it 'can handle translation options with random values' do 
+			expect{index.parse_translation_unit(fixture_path("a.c"), [], [], {:incomplete => 654, :single_file_parse => 8, :cache_completion_results => 93})}.not_to raise_error
+		end
+
+		it "raises error when one of the translation options is invalid" do
+			expect{index.parse_translation_unit(fixture_path("a.c"), [], [], [:incomplete, :random_option, :cache_completion_results])}.to raise_error(FFI::Clang::Error)
+		end
 	end
 
 	describe '#create_translation_unit' do


### PR DESCRIPTION
The translation unit class was missing several entries in the translation unit flags enum, specifically I was after the equivalent of 'CXTranslationUnit_SingleFileParse'. 

I updated the enum in question using the flags and values given here https://clang.llvm.org/doxygen/group__CINDEX__TRANSLATION__UNIT.html#gab1e4965c1ebe8e41d71e90203a723fe9 
and here
https://clang.llvm.org/doxygen/Index_8h_source.html#l01213

