### PR TITLE
Allow TranslationUnit file method to return TranslationUnits main file

### DIFF
--- a/lib/ffi/clang/translation_unit.rb
+++ b/lib/ffi/clang/translation_unit.rb
@@ -91,8 +91,12 @@ module FFI
 				ExpansionLocation.new Lib.get_location_offset(self, file, offset)
 			end
 
-			def file(file_name)
-				File.new(Lib.get_file(self, file_name), self)
+			def file(file_name = nil)
+				if file_name.nil?
+					File.new(Lib.get_file(self, Lib.get_translation_unit_spelling(self)), self)
+				else
+					File.new(Lib.get_file(self, file_name), self)
+				end
 			end
 
 			def spelling

--- a/spec/ffi/clang/translation_unit_spec.rb
+++ b/spec/ffi/clang/translation_unit_spec.rb
@@ -59,10 +59,16 @@ describe TranslationUnit do
 	end
 
 	describe "#file" do
-		let (:file) { translation_unit.file(fixture_path("a.c")) }
+		let (:specified_file) { translation_unit.file(fixture_path("a.c")) }
+		let (:unspecified_file) { translation_unit.file }
 
 		it "returns File instance" do
-			expect(file).to be_kind_of(FFI::Clang::File)
+			expect(specified_file).to be_kind_of(FFI::Clang::File)
+		end
+
+		it "returns main file when file name is not specified" do
+			expect(unspecified_file).to be_kind_of(FFI::Clang::File)
+			expect(unspecified_file.name).to include("a.c")
 		end
 	end
 


### PR DESCRIPTION
Similar to the cursor method, allow the file method to automatically retrieve the TranslationUnit's main file if no file is given.