### PR TITLE
Cursor and range visitor

### DIFF
--- a/lib/ffi/clang/lib/cursor.rb
+++ b/lib/ffi/clang/lib/cursor.rb
@@ -250,6 +250,15 @@ module FFI
 				)
 			end
 
+			enum :visitor_result, [:break, :continue]
+
+			class CXCursorAndRangeVisitor < FFI::Struct
+				layout(
+					:context, :pointer,
+					:visit, callback([:pointer, CXCursor.by_value, CXSourceRange.by_value], :visitor_result),
+				)
+			end
+
 			enum :cxx_access_specifier, [:invalid, :public, :protected, :private]
 			attach_function :get_cxx_access_specifier, :clang_getCXXAccessSpecifier, [CXCursor.by_value], :cxx_access_specifier
 
@@ -311,6 +320,9 @@ module FFI
 
 			callback :visit_children_function, [CXCursor.by_value, CXCursor.by_value, :pointer], :child_visit_result
 			attach_function :visit_children, :clang_visitChildren, [CXCursor.by_value, :visit_children_function, :pointer], :uint
+
+			enum :result, [:success, :invalid, :visit_break]
+			attach_function :find_references_in_file, :clang_findReferencesInFile, [CXCursor.by_value, :CXFile, CXCursorAndRangeVisitor.by_value], :result
 
 			attach_function :get_cursor_type, :clang_getCursorType, [CXCursor.by_value], CXType.by_value
 			attach_function :get_cursor_result_type, :clang_getCursorResultType, [CXCursor.by_value], CXType.by_value

--- a/lib/ffi/clang/translation_unit.rb
+++ b/lib/ffi/clang/translation_unit.rb
@@ -91,8 +91,12 @@ module FFI
 				ExpansionLocation.new Lib.get_location_offset(self, file, offset)
 			end
 
-			def file(file_name)
-				File.new(Lib.get_file(self, file_name), self)
+			def file(file_name = nil)
+				if file_name.nil?
+					File.new(Lib.get_file(self, Lib.get_translation_unit_spelling(self)), self)
+				else
+					File.new(Lib.get_file(self, file_name), self)
+				end
 			end
 
 			def spelling

--- a/spec/ffi/clang/cursor_spec.rb
+++ b/spec/ffi/clang/cursor_spec.rb
@@ -392,6 +392,28 @@ describe Cursor do
 		end
 	end
 
+	describe '#find_references_in_file' do
+		let (:struct_cursor) {find_first(cursor_canon, :cursor_struct) }
+
+		it "visits references to the cursor in the main file" do
+			counter = 0
+			struct_cursor.find_references_in_file do |ref_cursor, ref_src_loc|
+				counter += 1
+				:continue
+			end
+			expect(counter).not_to equal(0)
+		end
+
+		it "visits references to the cursor in the indicated file" do
+			counter = 0
+			struct_cursor.find_references_in_file(fixture_path("canonical.c")) do |ref_cursor, ref_src_loc|
+				counter += 1
+				:continue
+			end
+			expect(counter).not_to equal(0)
+		end
+	end
+
 	describe '#linkage' do
 		let (:ref) { find_first(cursor, :cursor_type_ref) }
 		let (:func) { find_first(cursor, :cursor_function) }

--- a/spec/ffi/clang/translation_unit_spec.rb
+++ b/spec/ffi/clang/translation_unit_spec.rb
@@ -59,10 +59,16 @@ describe TranslationUnit do
 	end
 
 	describe "#file" do
-		let (:file) { translation_unit.file(fixture_path("a.c")) }
+		let (:specified_file) { translation_unit.file(fixture_path("a.c")) }
+		let (:unspecified_file) { translation_unit.file }
 
 		it "returns File instance" do
-			expect(file).to be_kind_of(FFI::Clang::File)
+			expect(specified_file).to be_kind_of(FFI::Clang::File)
+		end
+
+		it "returns main file when file name is not specified" do
+			expect(unspecified_file).to be_kind_of(FFI::Clang::File)
+			expect(unspecified_file.name).to include("a.c")
 		end
 	end
 


### PR DESCRIPTION
I am very interested in using the [clang_findReferencesInFile](https://clang.llvm.org/doxygen/group__CINDEX__HIGH.html#gaa8524d179bc3668d215d326d332df97b) functionality, so I've implemented it here.  Because libclang notes this as a "higher level API", there doesn't seem to be a perfect fit for the definitions in the current ffi-clang design, but it seemed most closely associated with a cursor, so I implemented it there.