### PR TITLE
Cursor references

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -394,6 +394,15 @@ module FFI
 				filter.collect{|child, parent| child}
 			end
 
+			def references
+				refs = []
+				self.find_references_in_file do |cursor, unused|
+					refs << cursor
+					:continue
+				end
+				refs
+			end
+
 			class PlatformAvailability < AutoPointer
 				def initialize(memory_pointer)
 					pointer = FFI::Pointer.new(memory_pointer)

--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -394,9 +394,9 @@ module FFI
 				filter.collect{|child, parent| child}
 			end
 
-			def references
+			def references(file = nil)
 				refs = []
-				self.find_references_in_file do |cursor, unused|
+				self.find_references_in_file(file) do |cursor, unused|
 					refs << cursor
 					:continue
 				end

--- a/spec/ffi/clang/cursor_spec.rb
+++ b/spec/ffi/clang/cursor_spec.rb
@@ -672,6 +672,16 @@ describe Cursor do
 		end
 	end
 
+	describe '#references' do
+		let (:references) { find_first(cursor_canon, :cursor_struct).references }
+
+		it "returns an Array of reference Cursors" do
+			expect(references).to be_kind_of(Array)
+			expect(references).length).not_to equal(0)
+			expect(references).to all(be_a (FFI::Clang::Cursor))
+		end
+	end
+
 	describe Cursor::PlatformAvailability do
 		let(:func) { find_matching(cursor_cxx) { |child, parent|
 				child.kind == :cursor_function and child.spelling == 'availability_func'} }

--- a/spec/ffi/clang/cursor_spec.rb
+++ b/spec/ffi/clang/cursor_spec.rb
@@ -673,12 +673,20 @@ describe Cursor do
 	end
 
 	describe '#references' do
-		let (:references) { find_first(cursor_canon, :cursor_struct).references }
+		let (:struct_cursor) { find_first(cursor_canon, :cursor_struct) }
+		let (:unspecified_references) { struct_cursor.references }
+		let (:specified_references) { struct_cursor.references(fixture_path("canonical.c")) }
 
-		it "returns an Array of reference Cursors" do
-			expect(references).to be_kind_of(Array)
-			expect(references).length).not_to equal(0)
-			expect(references).to all(be_a (FFI::Clang::Cursor))
+		it "returns an Array of reference Cursors in the main file" do
+			expect(unspecified_references).to be_kind_of(Array)
+			expect(unspecified_references.length).not_to equal(0)
+			expect(unspecified_references).to all(be_a (FFI::Clang::Cursor))
+		end
+
+		it "returns an Array of reference Cursors in the specified file" do
+			expect(specified_references).to be_kind_of(Array)
+			expect(specified_references.length).not_to equal(0)
+			expect(specified_references).to all(be_a (FFI::Clang::Cursor))
 		end
 	end
 


### PR DESCRIPTION
Now that there's a method for visiting a Cursor's references within a file, it seems like there should be a convenience method for the most common use case, which, I imagine, would be to find all the references for something within a file so they could be operated on.

I've kept only the Cursors since the SourceRange can be extracted from the Cursor itself, making the second parameter kinda' redundant.