### PR TITLE
Fix warning on class re-definition, fix libclang path lookup for XCode, fix compilation_database_spec

### DIFF
--- a/lib/ffi/clang/lib.rb
+++ b/lib/ffi/clang/lib.rb
@@ -37,7 +37,15 @@ module FFI
 			libs = []
 			begin
 				xcode_dir = `xcode-select -p`.chomp
-				libs << "#{xcode_dir}/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib"
+				%W[
+					#{xcode_dir}/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib
+					#{xcode_dir}/usr/lib/libclang.dylib
+				].each do |f|
+					if File.exist? f
+						libs << f
+						break
+					end
+				end
 			rescue Errno::ENOENT
 				# Ignore
 			end

--- a/lib/ffi/clang/lib/diagnostic.rb
+++ b/lib/ffi/clang/lib/diagnostic.rb
@@ -22,18 +22,11 @@
 require_relative 'translation_unit'
 require_relative 'source_location'
 require_relative 'string'
+require_relative 'source_range'
 
 module FFI
 	module Clang
 		module Lib
-			class CXSourceRange < FFI::Struct
-				layout(
-					:ptr_data, [:pointer, 2],
-					:begin_int_data, :uint,
-					:end_int_data, :uint
-				)
-			end
-
 			typedef :pointer, :CXDiagnostic
 			typedef :pointer, :CXDiagnosticSet
 

--- a/spec/ffi/clang/compilation_database_spec.rb
+++ b/spec/ffi/clang/compilation_database_spec.rb
@@ -47,7 +47,11 @@ describe CompilationDatabase do
 
 		it "returns compile commands if the specified file is not found" do
 			expect(cdb.compile_commands(not_found_file)).to be_kind_of(CompilationDatabase::CompileCommands)
-			expect(cdb.compile_commands(not_found_file).size).to eq(0)
+			if FFI::Clang.clang_version_string[/\d+/].to_i >= 10
+				expect(cdb.compile_commands(not_found_file).size).to eq(1)
+			else
+				expect(cdb.compile_commands(not_found_file).size).to eq(0)
+			end
 		end
 	end
 
@@ -114,7 +118,7 @@ describe CompilationDatabase do
 		describe '#num_args' do
 			it "returns the number of CompileCommand" do
 				expect(cmd.num_args).to be_kind_of(Integer)
-				expect(cmd.num_args).to eq(31)
+				expect(cmd.num_args).to be >= 31 # clang may insert additional args
 			end
 		end
 


### PR DESCRIPTION
Works for apple clang version 12.0

But I'm not sure if the change of spec of `cdb.compile_commands(not_found_file).size` is fixing the right thing.