### PR TITLE
Fix incorrect return type of clang_getTranslationUnitSpelling

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -253,7 +253,7 @@ module FFI
 			end
 
 			def find_references_in_file(file = nil, &block)
-				file ||= Lib.get_translation_unit_spelling(@translation_unit)
+				file ||= Lib.extract_string Lib.get_translation_unit_spelling(@translation_unit)
 
 				visit_adapter = Proc.new do |unused, cxcursor, cxsource_range|
 					block.call Cursor.new(cxcursor, @translation_unit), SourceRange.new(cxsource_range)

--- a/lib/ffi/clang/lib/translation_unit.rb
+++ b/lib/ffi/clang/lib/translation_unit.rb
@@ -96,7 +96,7 @@ module FFI
 			attach_function :parse_translation_unit, :clang_parseTranslationUnit, [:CXIndex, :string, :pointer, :int, :pointer, :uint, :uint], :CXTranslationUnit
 			attach_function :create_translation_unit, :clang_createTranslationUnit, [:CXIndex, :string], :CXTranslationUnit
 			attach_function :dispose_translation_unit, :clang_disposeTranslationUnit, [:CXTranslationUnit], :void
-			attach_function :get_translation_unit_spelling, :clang_getTranslationUnitSpelling, [:CXTranslationUnit], :string
+			attach_function :get_translation_unit_spelling, :clang_getTranslationUnitSpelling, [:CXTranslationUnit], CXString.by_value
 
 			attach_function :default_editing_translation_unit_options, :clang_defaultEditingTranslationUnitOptions, [], :uint
 			attach_function :default_save_options, :clang_defaultSaveOptions, [:CXTranslationUnit], :uint

--- a/lib/ffi/clang/translation_unit.rb
+++ b/lib/ffi/clang/translation_unit.rb
@@ -93,14 +93,14 @@ module FFI
 
 			def file(file_name = nil)
 				if file_name.nil?
-					File.new(Lib.get_file(self, Lib.get_translation_unit_spelling(self)), self)
+					File.new(Lib.get_file(self, spelling), self)
 				else
 					File.new(Lib.get_file(self, file_name), self)
 				end
 			end
 
 			def spelling
-				Lib.get_translation_unit_spelling(self)
+				Lib.extract_string Lib.get_translation_unit_spelling(self)
 			end
 
 			def resource_usage


### PR DESCRIPTION
The return type of `clang_getTranslationUnitSpelling` is `CXString`, not `char *`.

/usr/include/clang-c/Index.h:
```
CINDEX_LINKAGE CXString
clang_getTranslationUnitSpelling(CXTranslationUnit CTUnit);
```