### PR TITLE
The enum value for CXCursor_TranslationUnit  is 350. 

### DIFF
--- a/lib/ffi/clang/lib/cursor.rb
+++ b/lib/ffi/clang/lib/cursor.rb
@@ -232,7 +232,7 @@ module FFI
 				:cursor_omp_depobj_directive, 286,
 				:cursor_omp_scan_directive, 287,
 				# :cursor_last_stmt, :cursor_omp_scan_directive,
-				:cursor_translation_unit, 300,
+				:cursor_translation_unit, 350,
 				:cursor_first_attr, 400,
 				:cursor_unexposed_attr, 400,
 				:cursor_ibaction_attr, 401,


### PR DESCRIPTION
See https://githhub.com/llvm/llvm-project/blob/main/clang/include/clang-c/Index.h#L2143