### PR TITLE
Remove duplicate mapping of clang_getEnumDeclIntegerType

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -148,10 +148,6 @@ module FFI
 				Type.new Lib.get_typedef_decl_underlying_type(@cursor), @translation_unit
 			end
 
-			def enum_decl_integer_type
-				Type.new Lib.get_enum_decl_integer_type(@cursor), @translation_unit
-			end
-
 			def typedef_type
 				Type.new Lib.get_typedef_decl_unerlying_type(@cursor), @translation_unit
 			end

--- a/lib/ffi/clang/lib/cursor.rb
+++ b/lib/ffi/clang/lib/cursor.rb
@@ -442,7 +442,7 @@ module FFI
 			attach_function :get_cursor_type, :clang_getCursorType, [CXCursor.by_value], CXType.by_value
 			attach_function :get_cursor_result_type, :clang_getCursorResultType, [CXCursor.by_value], CXType.by_value
 			attach_function :get_typedef_decl_underlying_type, :clang_getTypedefDeclUnderlyingType, [CXCursor.by_value], CXType.by_value
-			attach_function :get_enum_decl_integer_type, :clang_getEnumDeclIntegerType, [CXCursor.by_value], CXType.by_value
+      attach_function :get_enum_type, :clang_getEnumDeclIntegerType, [CXCursor.by_value], CXType.by_value
 			attach_function :get_type_declaration, :clang_getTypeDeclaration, [CXType.by_value], FFI::Clang::Lib::CXCursor.by_value
 
 			attach_function :get_cursor_referenced, :clang_getCursorReferenced, [CXCursor.by_value], CXCursor.by_value
@@ -472,8 +472,6 @@ module FFI
 			attach_function :dispose_overridden_cursors, :clang_disposeOverriddenCursors, [:pointer], :void
 
 			attach_function :get_typedef_decl_unerlying_type, :clang_getTypedefDeclUnderlyingType, [CXCursor.by_value], CXType.by_value
-
-			attach_function :get_enum_type, :clang_getEnumDeclIntegerType, [CXCursor.by_value], CXType.by_value
 
 			attach_function :get_num_args, :clang_Cursor_getNumArguments, [CXCursor.by_value], :int
 

--- a/spec/ffi/clang/cursor_spec.rb
+++ b/spec/ffi/clang/cursor_spec.rb
@@ -612,13 +612,13 @@ describe Cursor do
 		end
 	end
 
-	describe '#enum_decl_integer_type' do
+	describe '#enum_type' do
 		let(:enum) { find_matching(cursor_cxx) { |child, parent|
 				child.kind == :cursor_enum_decl and child.spelling == 'normal_enum' } }
 
 		it "returns the integer type of the enum declaration" do
-			expect(enum.enum_decl_integer_type).to be_kind_of(Type)
-			expect(enum.enum_decl_integer_type.kind).to be(:type_uint)
+			expect(enum.enum_type).to be_kind_of(Type)
+			expect(enum.enum_type.kind).to be(:type_uint)
 		end
 	end
 


### PR DESCRIPTION
One was get_enum_decl_integer_type while the other was get_enum_type. I went with get_enum_type.