### PR TITLE
Update bitmask options based on enums to always be an array of symbols.

### DIFF
--- a/lib/ffi/clang/code_completion.rb
+++ b/lib/ffi/clang/code_completion.rb
@@ -10,7 +10,7 @@ module FFI
 	module Clang
 		class CodeCompletion
 			def self.default_code_completion_options
-				Lib.opts_from Lib::CodeCompleteFlags, Lib.default_code_completion_options
+				Lib.opts_from(Lib::CodeCompleteFlags, Lib.default_code_completion_options)
 			end
 
 			class Results < FFI::AutoPointer

--- a/lib/ffi/clang/diagnostic.rb
+++ b/lib/ffi/clang/diagnostic.rb
@@ -14,7 +14,7 @@ module FFI
 	module Clang
 		class Diagnostic < AutoPointer
 			def self.default_display_opts
-				Lib.opts_from Lib::DiagnosticDisplayOptions, Lib.default_diagnostic_display_options
+				Lib.opts_from(Lib::DiagnosticDisplayOptions, Lib.default_diagnostic_display_options)
 			end
 
 			def initialize(translation_unit, pointer)
@@ -96,7 +96,7 @@ module FFI
 				if opts.empty?
 					Lib.default_diagnostic_display_options
 				else
-					Lib.bitmask_from Lib::DiagnosticDisplayOptions, opts
+					Lib.bitmask_from(Lib::DiagnosticDisplayOptions, opts)
 				end
 			end
 		end

--- a/lib/ffi/clang/index.rb
+++ b/lib/ffi/clang/index.rb
@@ -22,7 +22,7 @@ module FFI
 				Lib.dispose_index(pointer)
 			end
 
-			def parse_translation_unit(source_file, command_line_args = nil, unsaved = [], opts = {})
+			def parse_translation_unit(source_file, command_line_args = nil, unsaved = [], opts = [])
 				command_line_args = Array(command_line_args)
 				unsaved_files = UnsavedFile.unsaved_pointer_from(unsaved)
 
@@ -53,7 +53,7 @@ module FFI
 			end
 
 			def options_bitmask_from(opts)
-				Lib.bitmask_from Lib::TranslationUnitFlags, opts
+				Lib.bitmask_from(Lib::TranslationUnitFlags, opts)
 			end
 		end
 	end

--- a/lib/ffi/clang/lib.rb
+++ b/lib/ffi/clang/lib.rb
@@ -69,11 +69,11 @@ module FFI
 			def self.bitmask_from(enum, opts)
 				bitmask = 0
 
-				opts.each do |key, value|
-					if int = enum[key]
+				opts.each do |symbol|
+					if int = enum[symbol]
 						bitmask |= int
 					else
-						raise Error, "unknown option: #{key.inspect}, expected one of #{enum.symbols}"
+  						raise Error, "unknown option: #{symbol}, expected one of #{enum.symbols}"
 					end
 				end
 
@@ -82,19 +82,19 @@ module FFI
 
 			def self.opts_from(enum, bitmask)
 				bit = 1
-				opts = {}
+				result = []
 				while bitmask != 0
 					if bitmask & 1
-						if sym = enum[bit]
-							opts[sym] = true
+						if symbol = enum[bit]
+							result << symbol
 						else
-							raise Error, "unknown values: #{bit}, expected one of #{enum.symbols}"
+							raise(Error, "unknown values: #{bit}, expected one of #{enum.symbols}")
 						end
 					end
 					bitmask >>= 1
 					bit <<= 1
 				end
-				opts
+				result
 			end
 		end
 	end

--- a/spec/ffi/clang/code_completion_spec.rb
+++ b/spec/ffi/clang/code_completion_spec.rb
@@ -14,9 +14,9 @@ describe CodeCompletion do
 	describe "self.default_code_completion_options" do
 		let(:options) { FFI::Clang::CodeCompletion.default_code_completion_options }
 		it "returns a default set of code-completion options" do
-			expect(options).to be_kind_of(Hash)
-			options.keys.each { |key|
-				expect(FFI::Clang::Lib::CodeCompleteFlags.symbols).to include(key)
+			expect(options).to be_kind_of(Array)
+			options.each {|symbol|
+				expect(FFI::Clang::Lib::CodeCompleteFlags.symbols).to include(symbol)
 			}
 		end
 	end
@@ -58,9 +58,9 @@ describe CodeCompletion do
 		end
 
 		it "#contexts" do
-			expect(results.contexts).to be_kind_of(Hash)
-			results.contexts.keys.each { |key|
-				expect(FFI::Clang::Lib::CompletionContext.symbols).to include(key)
+			expect(results.contexts).to be_kind_of(Array)
+			results.contexts.each {|symbol|
+				expect(FFI::Clang::Lib::CompletionContext.symbols).to include(symbol)
 			}
 		end
 

--- a/spec/ffi/clang/cursor_spec.rb
+++ b/spec/ffi/clang/cursor_spec.rb
@@ -102,7 +102,7 @@ describe Cursor do
 	let(:cursor) { Index.new.parse_translation_unit(fixture_path("list.c")).cursor }
 	let(:cursor_cxx) { Index.new.parse_translation_unit(fixture_path("test.cxx")).cursor }
 	let(:cursor_canon) { Index.new.parse_translation_unit(fixture_path("canonical.c")).cursor }
-	let(:cursor_pp) { Index.new.parse_translation_unit(fixture_path("docs.c"),[],[],{detailed_preprocessing_record: true}).cursor }
+	let(:cursor_pp) { Index.new.parse_translation_unit(fixture_path("docs.c"),[],[],[:detailed_preprocessing_record]).cursor }
 
 	it "can be obtained from a translation unit" do
 		expect(cursor).to be_kind_of(Cursor)

--- a/spec/ffi/clang/diagnostic_spec.rb
+++ b/spec/ffi/clang/diagnostic_spec.rb
@@ -17,7 +17,7 @@ describe Diagnostic do
 	end
 
 	it "returns a string representation according to the given opts" do
-		expect(diagnostic.format(:source_location => true)).to include("list.c:5")
+		expect(diagnostic.format([:source_location])).to include("list.c:5")
 	end
 
 	it "returns the text of the diagnostic" do
@@ -43,9 +43,9 @@ describe Diagnostic do
 
 	context "#self.default_display_opts" do
 		it "returns the set of display options" do
-			expect(FFI::Clang::Diagnostic.default_display_opts).to be_kind_of(Hash)
-			expect(FFI::Clang::Diagnostic.default_display_opts.keys.map(&:class).uniq).to eq([Symbol])
-			expect(FFI::Clang::Diagnostic.default_display_opts.values.uniq).to eq([true])
+			expect(FFI::Clang::Diagnostic.default_display_opts).to be_kind_of(Array)
+			expect(FFI::Clang::Diagnostic.default_display_opts.map(&:class).uniq).to eq([Symbol])
+			expect(FFI::Clang::Diagnostic.default_display_opts.uniq).to eq([:source_location, :column, :source_ranges, :option])
 		end
 	end
 

--- a/spec/ffi/clang/index_spec.rb
+++ b/spec/ffi/clang/index_spec.rb
@@ -47,8 +47,8 @@ describe Index do
 			expect{index.parse_translation_unit(fixture_path("a.c"), [], [], [])}.not_to raise_error
 		end
 
-		it 'can handle translation options with random values' do 
-			expect{index.parse_translation_unit(fixture_path("a.c"), [], [], {:incomplete => 654, :single_file_parse => 8, :cache_completion_results => 93})}.not_to raise_error
+		it 'throws error on options with random values' do
+			expect{index.parse_translation_unit(fixture_path("a.c"), [], [], [:not_valid])}.to raise_error
 		end
 
 		it "raises error when one of the translation options is invalid" do

--- a/spec/ffi/clang/translation_unit_spec.rb
+++ b/spec/ffi/clang/translation_unit_spec.rb
@@ -106,9 +106,9 @@ describe TranslationUnit do
 	describe "#self.default_editing_translation_unit_options" do
 		let (:opts) { FFI::Clang::TranslationUnit.default_editing_translation_unit_options }
 		it "returns hash with symbols of TranslationUnitFlags" do
-			expect(opts).to be_kind_of(Hash)
-			opts.keys.each { |key|
-				expect(FFI::Clang::Lib::TranslationUnitFlags.symbols).to include(key)
+			expect(opts).to be_kind_of(Array)
+			opts.each {|symbol|
+				expect(FFI::Clang::Lib::TranslationUnitFlags.symbols).to include(symbol)
 			}
 		end
 	end
@@ -116,9 +116,9 @@ describe TranslationUnit do
 	describe "#default_save_options" do
 		let (:opts) { translation_unit.default_save_options }
 		it "returns hash with symbols of SaveTranslationUnitFlags" do
-			expect(opts).to be_kind_of(Hash)
-			opts.keys.each { |key|
-				expect(FFI::Clang::Lib::SaveTranslationUnitFlags.symbols).to include(key)
+			expect(opts).to be_kind_of(Array)
+			opts.each {|symbol|
+				expect(FFI::Clang::Lib::SaveTranslationUnitFlags.symbols).to include(symbol)
 			}
 		end
 	end
@@ -142,9 +142,9 @@ describe TranslationUnit do
 	describe "#default_reparse_options" do
 		let (:opts) { translation_unit.default_reparse_options }
 		it "returns hash with symbols of ReparseFlags" do
-			expect(opts).to be_kind_of(Hash)
-			opts.keys.each { |key|
-				expect(FFI::Clang::Lib::ReparseFlags.symbols).to include(key)
+			expect(opts).to be_kind_of(Array)
+			opts.each {|symbol|
+				expect(FFI::Clang::Lib::ReparseFlags.symbols).to include(symbol)
 			}
 		end
 	end


### PR DESCRIPTION
See https://github.com/ioquatix/ffi-clang/issues/68.