### PR TITLE
Cursor Location Methods

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -110,8 +110,21 @@ module FFI
 				Lib.is_unexposed(kind) != 0
 			end
 
-			def location
+			def expansion_location
 				ExpansionLocation.new(Lib.get_cursor_location(@cursor))
+			end
+			alias :location :expansion_location
+
+			def presumed_location
+				PresumedLocation.new(Lib.get_cursor_location(@cursor))
+			end
+
+			def spelling_location
+				SpellingLocation.new(Lib.get_cursor_location(@cursor))
+			end
+
+			def file_location
+				FileLocation.new(Lib.get_cursor_location(@cursor))
 			end
 
 			def extent

--- a/lib/ffi/clang/source_location.rb
+++ b/lib/ffi/clang/source_location.rb
@@ -30,22 +30,6 @@ module FFI
 				Lib.location_is_from_main_file(@location) != 0
 			end
 
-			def expansion_location
-				ExpansionLocation.new(@location)
-			end
-
-			def presumed_location
-				PresumedLocation.new(@location)
-			end
-
-			def spelling_location
-				SpellingLocation.new(@location)
-			end
-
-			def file_location
-				FileLocation.new(@location)
-			end
-
 			def null?
 				Lib.equal_locations(@location, Lib.get_null_location) != 0
 			end
@@ -73,6 +57,14 @@ module FFI
 				@column = column.get_uint(0)
 				@offset = offset.get_uint(0)
 			end
+
+			def as_string
+				"#{@file}:#{@line}:#{@column}:#{@offset}"
+			end
+
+			def to_s
+				"ExpansionLocation <#{self.as_string}>"
+			end
 		end
 
 		class PresumedLocation < SourceLocation
@@ -82,14 +74,22 @@ module FFI
 				super(location)
 
 				cxstring = MemoryPointer.new Lib::CXString
-				line	 = MemoryPointer.new :uint
-				column	 = MemoryPointer.new :uint
+				line   = MemoryPointer.new :uint
+				column   = MemoryPointer.new :uint
 
 				Lib::get_presumed_location(@location, cxstring, line, column)
 
 				@filename = Lib.extract_string cxstring
 				@line = line.get_uint(0)
 				@column = column.get_uint(0)
+			end
+
+			def as_string
+				"#{@filename}:#{@line}:#{@column}"
+			end
+
+			def to_s
+				"PresumedLocation <#{self.as_string}>"
 			end
 		end
 
@@ -111,6 +111,14 @@ module FFI
 				@column = column.get_uint(0)
 				@offset = offset.get_uint(0)
 			end
+
+			def as_string
+				"#{@file}:#{@line}:#{@column}:#{@offset}"
+			end
+
+			def to_s
+				"SpellingLocation <#{self.as_string}>"
+			end
 		end
 
 		class FileLocation < SourceLocation
@@ -130,6 +138,14 @@ module FFI
 				@line = line.get_uint(0)
 				@column = column.get_uint(0)
 				@offset = offset.get_uint(0)
+			end
+
+			def as_string
+				"#{@file}:#{@line}:#{@column}:#{@offset}"
+			end
+
+			def to_s
+				"FileLocation <#{self.as_string}>"
 			end
 		end
 	end

--- a/lib/ffi/clang/source_location.rb
+++ b/lib/ffi/clang/source_location.rb
@@ -74,8 +74,8 @@ module FFI
 				super(location)
 
 				cxstring = MemoryPointer.new Lib::CXString
-				line   = MemoryPointer.new :uint
-				column   = MemoryPointer.new :uint
+				line = MemoryPointer.new :uint
+				column = MemoryPointer.new :uint
 
 				Lib::get_presumed_location(@location, cxstring, line, column)
 

--- a/spec/ffi/clang/source_location_spec.rb
+++ b/spec/ffi/clang/source_location_spec.rb
@@ -64,7 +64,7 @@ describe SourceLocation do
 	end
 
 	describe "#expansion_location" do
-		let (:expansion_location) { loc1_cursor.location.expansion_location }
+		let (:expansion_location) { loc1_cursor.expansion_location }
 
 		it "should be ExpansionLocaion" do
 			expect(expansion_location).to be_kind_of(SourceLocation)
@@ -77,7 +77,7 @@ describe SourceLocation do
 	end
 
 	describe "#presumed_location" do
-		let (:presumed_location) { loc1_cursor.location.presumed_location }
+		let (:presumed_location) { loc1_cursor.presumed_location }
 
 		it "should be FileLocaion" do
 			expect(presumed_location).to be_kind_of(SourceLocation)
@@ -94,7 +94,7 @@ describe SourceLocation do
 	end
 
 	describe "#file_location" do
-		let (:file_location) { loc1_cursor.location.file_location }
+		let (:file_location) { loc1_cursor.file_location }
 
 		it "should be FileLocaion" do
 			expect(file_location).to be_kind_of(SourceLocation)
@@ -107,7 +107,7 @@ describe SourceLocation do
 	end
 
 	describe "#spelling_location" do
-		let (:spelling_location) { loc1_cursor.location.spelling_location }
+		let (:spelling_location) { loc1_cursor.spelling_location }
 
 		it "should be SpellingLocaion" do
 			expect(spelling_location).to be_kind_of(SourceLocation)


### PR DESCRIPTION
Instead of having methods on the base class SourceLocation that create subclasses (which at least I found surprising), just add the appropriate getter methods on cursor.

Also added #as_text and #to_s for easier debugging.