### PR TITLE
Fix Qualified name

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -146,6 +146,9 @@ module FFI
 
 			def qualified_name
 				if self.kind != :cursor_translation_unit
+					if self.semantic_parent.kind == :cursor_invalid_file
+						raise(ArgumentError, "Invalid semantic parent: #{self}")
+					end
 					result = self.semantic_parent.qualified_name
 					result ? "#{result}::#{self.spelling}" : self.spelling
 				end

--- a/spec/ffi/clang/cursor_spec.rb
+++ b/spec/ffi/clang/cursor_spec.rb
@@ -673,6 +673,21 @@ describe Cursor do
 		end
 	end
 
+	describe '#qualified_name' do
+		let(:qualified) { find_matching(cursor_cxx) { |child, parent|
+			child.kind == :cursor_struct and child.spelling == 'B' } }
+		let(:base_class)  { find_matching(qualified) { |child, parent|
+			child.kind == :cursor_cxx_base_specifier } }
+
+		it "returns a qualified name for struct" do
+			expect(qualified.qualified_name).to eq("B")
+		end
+
+		it "throws error for base class qualified name" do
+			expect{base_class.qualified_name}.to raise_error(ArgumentError)
+		end
+	end
+
 	describe '#objc_type_encoding' do
 		#TODO
 	end


### PR DESCRIPTION
Some cursors, such as C++ base reference classes, do not have valid semantic parents. In such cases, the #qualified_name method would previously call itself forever resulting in a stack overflow. This commit fixes the issue by checking if the semantic parent is valid.