### PR TITLE
Function Type Updates

### DIFF
--- a/lib/ffi/clang/types/function.rb
+++ b/lib/ffi/clang/types/function.rb
@@ -2,6 +2,8 @@ module FFI
 	module Clang
 		module Types
 			class Function < Type
+				include Enumerable
+
 				def variadic?
 					Lib.is_function_type_variadic(@type) != 0
 				end
@@ -12,6 +14,16 @@ module FFI
 
 				def arg_type(i)
 					Type.create Lib.get_arg_type(@type, i), @translation_unit
+				end
+
+				def arg_types
+					return to_enum(:arg_types) unless block_given?
+
+					self.args_size.times do |i|
+						yield self.arg_type(i)
+					end
+
+					self
 				end
 
 				def result_type

--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -14,7 +14,7 @@ module FFI
 			class Type
 				attr_reader :type, :translation_unit
 
-				# Just hard code the types - they don't likely to change
+				# Just hard code the types - they are not likely to change
 				def self.create(cxtype, translation_unit)
 					case cxtype[:kind]
 						when :type_pointer, :type_block_pointer, :type_obj_c_object_pointer, :type_member_pointer
@@ -83,6 +83,10 @@ module FFI
 
 				def declaration
 					Cursor.new Lib.get_type_declaration(@type), @translation_unit
+				end
+
+				def non_reference_type
+					Type.create Lib.get_non_reference_type(@type),@translation_unit
 				end
 
 				def ==(other)

--- a/spec/ffi/clang/fixtures/test.cxx
+++ b/spec/ffi/clang/fixtures/test.cxx
@@ -1,5 +1,6 @@
 struct A {
   virtual int func_a() = 0;
+  void takesARef(int& lValue, float&& rValue);
   int int_member_a;
 };
 

--- a/spec/ffi/clang/type_spec.rb
+++ b/spec/ffi/clang/type_spec.rb
@@ -54,6 +54,26 @@ describe FFI::Clang::Types::Type do
     end
   end
 
+	describe '#function_type' do
+		let(:reference_type) { find_matching(cursor_cxx) { |child, parent|
+			child.kind == :cursor_cxx_method and child.spelling == 'takesARef'
+		}.type }
+
+		it 'iterates arg_types' do
+			expect(reference_type).to be_kind_of(Types::Function)
+			expect(reference_type.arg_types.to_a).to be_kind_of(Array)
+			expect(reference_type.arg_types.to_a.size).to eq(2)
+		end
+
+		it 'supports non-reference arg_types' do
+			args_types = reference_type.arg_types.to_a
+			expect(args_types[0].kind).to eq(:type_lvalue_ref)
+			expect(args_types[0].non_reference_type.kind).to eq(:type_int)
+			expect(args_types[1].kind).to eq(:type_rvalue_ref)
+			expect(args_types[1].non_reference_type.kind).to eq(:type_float)
+		end
+	end
+
   describe '#const_qualified?' do
     let(:pointer_type) { find_matching(cursor_cxx) { |child, parent|
         child.kind == :cursor_typedef_decl and child.spelling == 'const_int_ptr'


### PR DESCRIPTION
Support iterating over Type::Function args and expose Lib.get_non_reference_type.