### PR TITLE
Type Updates

### DIFF
--- a/lib/ffi/clang/lib/type.rb
+++ b/lib/ffi/clang/lib/type.rb
@@ -192,6 +192,7 @@ module FFI
 
 			attach_function :get_type_kind_spelling, :clang_getTypeKindSpelling, [:kind], CXString.by_value
 			attach_function :get_type_spelling, :clang_getTypeSpelling, [CXType.by_value], CXString.by_value
+			attach_function :get_named_type, :clang_Type_getNamedType, [CXType.by_value], CXType.by_value
 
 			attach_function :is_function_type_variadic, :clang_isFunctionTypeVariadic, [CXType.by_value], :uint
 			attach_function :is_pod_type, :clang_isPODType, [CXType.by_value], :uint

--- a/lib/ffi/clang/types/elaborated.rb
+++ b/lib/ffi/clang/types/elaborated.rb
@@ -2,8 +2,8 @@ module FFI
 	module Clang
 		module Types
 			class Elaborated < Type
-				def canonical
-					Type.create Lib.get_canonical_type(@type), @translation_unit
+				def named_type
+					Type.create Lib.get_named_type(@type), @translation_unit
 				end
 
 				# Example anonymous union where `u` is an elaborated type

--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -53,6 +53,10 @@ module FFI
 					Lib.extract_string Lib.get_type_spelling(@type)
 				end
 
+				def canonical
+					Type.create Lib.get_canonical_type(@type), @translation_unit
+				end
+
 				def pod?
 					Lib.is_pod_type(@type) != 0
 				end


### PR DESCRIPTION
Move #canonical from to the base Type class since it applies to all Types. Then add new Clang API, get_named_type.