### PR TITLE
Add qualified_display_name helper

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -144,6 +144,16 @@ module FFI
 				Lib.extract_string Lib.get_cursor_display_name(@cursor)
 			end
 
+			def qualified_display_name
+				if self.kind != :cursor_translation_unit
+					if self.semantic_parent.kind == :cursor_invalid_file
+						raise(ArgumentError, "Invalid semantic parent: #{self}")
+					end
+					result = self.semantic_parent.qualified_name
+					result ? "#{result}::#{self.display_name}" : self.spelling
+				end
+			end
+
 			def qualified_name
 				if self.kind != :cursor_translation_unit
 					if self.semantic_parent.kind == :cursor_invalid_file


### PR DESCRIPTION
Helper method that returns a curors's qualified_display_name. This is similar to qualified_name but provides more information. For example, a qualified_display_name might be "cv::Seq<_Tp>" but the qualified_name will be "cv::Seq"