### PR TITLE
Template Arguments API

### DIFF
--- a/lib/ffi/clang/lib/type.rb
+++ b/lib/ffi/clang/lib/type.rb
@@ -224,6 +224,9 @@ module FFI
 			attach_function :get_exception_specification_type, :clang_getExceptionSpecificationType, [CXType.by_value], :exception_specification_type
 
 			attach_function :equal_types, :clang_equalTypes, [CXType.by_value, CXType.by_value], :uint
+
+			attach_function :get_num_template_arguments, :clang_Type_getNumTemplateArguments, [CXType.by_value], :int
+			attach_function :get_template_argument_as_type, :clang_Type_getTemplateArgumentAsType, [CXType.by_value, :uint], CXType.by_value
 		end
 	end
 end

--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -90,7 +90,15 @@ module FFI
 				end
 
 				def non_reference_type
-					Type.create Lib.get_non_reference_type(@type),@translation_unit
+					Type.create Lib.get_non_reference_type(@type), @translation_unit
+				end
+
+				def template_argument_type(index)
+					Type.create Lib.get_template_argument_as_type(@type, index), @translation_unit
+				end
+
+				def num_template_arguments
+					Lib.get_num_template_arguments(@type)
 				end
 
 				def ==(other)


### PR DESCRIPTION
Expose libclang methods to get template arguments. Unfortunately, these method do not work for me  - meaning you can call them fine but the do not seem to return any results. Thus no tests. Maybe I am miss using them?