### PR TITLE
Guard Type#unqualified_type against type_invalid input

### DIFF
--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -127,7 +127,14 @@ module FFI
 				
 				# Get the type with all qualifiers (const, volatile, restrict) removed.
 				# @returns [Type] The unqualified type.
+				#
+				# Guards against :type_invalid input: clang_getUnqualifiedType has
+				# no null check on the underlying QualType (unlike its siblings
+				# clang_getNonReferenceType / clang_getCanonicalType / etc.) and
+				# segfaults on invalid types. Returning self preserves the
+				# invalid kind without entering libclang.
 				def unqualified_type
+					return self if self.kind == :type_invalid
 					Type.create Lib.get_unqualified_type(@type), @translation_unit
 				end
 				

--- a/spec/ffi/clang/type_spec.rb
+++ b/spec/ffi/clang/type_spec.rb
@@ -164,6 +164,21 @@ describe FFI::Clang::Types::Type do
 			expect(int_type.const_qualified?).to be false
 			expect(int_type.unqualified_type.kind).to eq(int_type.kind)
 		end
+		
+		# clang_getUnqualifiedType has no null check for the underlying QualType
+		# (unlike its siblings like clang_getNonReferenceType), so calling it on
+		# CXType_Invalid segfaults inside libclang. ffi-clang must guard against
+		# this — invalid input should yield an invalid output, not a crash.
+		it "returns an invalid type without crashing on a type_invalid input" do
+			invalid_cxtype = FFI::Clang::Lib::CXType.new
+			# Fresh CXType has kind = 0 = :type_invalid
+			invalid_type = FFI::Clang::Types::Type.new(invalid_cxtype, nil)
+			expect(invalid_type.kind).to eq(:type_invalid)
+			
+			result = invalid_type.unqualified_type
+			expect(result).to be_kind_of(Types::Type)
+			expect(result.kind).to eq(:type_invalid)
+		end
 	end
 	
 	describe "#const_qualified?" do


### PR DESCRIPTION
## Types of Changes

- Bug fix.

## Description

`clang_getUnqualifiedType` has no null check on the underlying `QualType` and segfaults libclang when called on `CXType_Invalid`. Sibling type-walker APIs (`clang_getNonReferenceType`, `clang_getCanonicalType`, `clang_getPointeeType`) all guard against null `QualType` internally, so they fail gracefully on invalid input — but `getUnqualifiedType` does not.

This is reachable from real-world Ruby code that walks libclang types defensively. For example, in [ruby-bindgen](https://github.com/ruby-rice/ruby-bindgen) we follow pointer indirection (`pointee` chain) and call `unqualified_type` on the result for skip-list/bindability checks. When the chain lands on an unresolvable pointee, `pointee.kind` is `:type_invalid` and the next call into `unqualified_type` crashes the entire process.

The fix adds a one-line guard in `Type#unqualified_type` so invalid input returns an invalid `Type` rather than entering libclang.

## Repro

```ruby
require "ffi/clang"

invalid_cxtype = FFI::Clang::Lib::CXType.new
# Fresh CXType has kind = 0 = :type_invalid
invalid_type = FFI::Clang::Types::Type.new(invalid_cxtype, nil)
invalid_type.unqualified_type  # segfault before this PR
```

The new spec example in `type_spec.rb` exercises exactly this case.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).