### PR TITLE
Guard Type#non_reference_type against type_invalid input

### DIFF
--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -134,7 +134,13 @@ module FFI
 				# Get the non-reference type.
 				# For reference types, returns the type that is being referenced.
 				# @returns [Type] The non-reference type.
+				#
+				# Guards against :type_invalid input: clang_getNonReferenceType
+				# dereferences the underlying QualType without a null check and
+				# segfaults on invalid types. Returning self preserves the
+				# invalid kind without entering libclang.
 				def non_reference_type
+					return self if self.kind == :type_invalid
 					Type.create Lib.get_non_reference_type(@type), @translation_unit
 				end
 				

--- a/spec/ffi/clang/type_spec.rb
+++ b/spec/ffi/clang/type_spec.rb
@@ -142,6 +142,23 @@ describe FFI::Clang::Types::Type do
 		end
 	end
 	
+	describe "#non_reference_type" do
+		# clang_getNonReferenceType dereferences the underlying QualType
+		# without a null check, so calling it on CXType_Invalid segfaults
+		# inside libclang. ffi-clang must guard against this — invalid input
+		# should yield an invalid output, not a crash.
+		it "returns an invalid type without crashing on a type_invalid input" do
+			invalid_cxtype = FFI::Clang::Lib::CXType.new
+			# Fresh CXType has kind = 0 = :type_invalid
+			invalid_type = FFI::Clang::Types::Type.new(invalid_cxtype, nil)
+			expect(invalid_type.kind).to eq(:type_invalid)
+			
+			result = invalid_type.non_reference_type
+			expect(result).to be_kind_of(Types::Type)
+			expect(result.kind).to eq(:type_invalid)
+		end
+	end
+	
 	describe "#unqualified_type" do
 		let(:const_type) do
 			find_matching(cursor_cxx) do |child, parent|


### PR DESCRIPTION
## Types of Changes

- Bug fix.

## Description

`clang_getNonReferenceType` dereferences the underlying `QualType` without a null check and segfaults libclang on `CXType_Invalid`. This is the same shape of bug as `clang_getUnqualifiedType` (see #132); both sibling APIs need the same Ruby-layer guard.

This is reachable from real-world Ruby code that walks libclang types defensively. Composing operations like `type.non_reference_type` on the output of an unrelated libclang call (where any of the intermediate types may resolve to `type_invalid`) crashes the process rather than letting the caller handle the invalid case.

The fix adds a one-line `kind` check at the top of `Type#non_reference_type` so invalid input returns the invalid `Type` rather than entering libclang.

## Repro

```ruby
require \"ffi/clang\"

invalid_cxtype = FFI::Clang::Lib::CXType.new
# Fresh CXType has kind = 0 = :type_invalid
invalid_type = FFI::Clang::Types::Type.new(invalid_cxtype, nil)
invalid_type.non_reference_type  # segfault before this PR
```

The new spec example in \`type_spec.rb\` exercises exactly this case.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).