### PR TITLE
Add Type#intrinsic_type for cv-ref-pointer stripping

### DIFF
--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -151,6 +151,27 @@ module FFI
 					Type.create Lib.get_non_reference_type(@type), @translation_unit
 				end
 				
+				# Get the intrinsic type — strip the reference, follow pointer
+				# indirection until reaching a non-pointer type, then drop
+				# cv-qualifiers. Named after Rice's `intrinsic_type` metafunction
+				# of the same shape. Useful when asking "what does this type
+				# ultimately denote?" for skip-list and bindability checks.
+				#
+				# Examples:
+				# * `T &`        becomes `T`
+				# * `T *`        becomes `T`
+				# * `T **&`      becomes `T`
+				# * `const T &`  becomes `T`
+				#
+				# @returns [Type] The intrinsic (innermost, unqualified) type.
+				def intrinsic_type
+					type = self.non_reference_type
+					while type.kind == :type_pointer
+						type = type.pointee
+					end
+					type.unqualified_type
+				end
+				
 				# Get the type of a template argument at the given index.
 				# For template specializations (e.g., `std::vector<int>`), this returns the type of
 				# the template argument at the specified position.

--- a/spec/ffi/clang/fixtures/test.cxx
+++ b/spec/ffi/clang/fixtures/test.cxx
@@ -40,6 +40,8 @@ void f_variadic(int a, ...);
 void f_non_variadic(int a, char b, long c);
 
 typedef int const* const_int_ptr;
+typedef int** int_pp;
+void takesPtrRefs(int*& pRef, int**& ppRef);
 int int_array[8];
 
 struct RefQualifier {

--- a/spec/ffi/clang/type_spec.rb
+++ b/spec/ffi/clang/type_spec.rb
@@ -198,6 +198,90 @@ describe FFI::Clang::Types::Type do
 		end
 	end
 	
+	describe "#intrinsic_type" do
+		it "strips an lvalue reference" do
+			ref_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_cxx_method and child.spelling == "takesARef"
+			end.type.arg_types.to_a[0]
+			expect(ref_type.kind).to eq(:type_lvalue_ref)
+			
+			intrinsic = ref_type.intrinsic_type
+			expect(intrinsic.kind).to eq(:type_int)
+		end
+		
+		it "strips an rvalue reference" do
+			ref_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_cxx_method and child.spelling == "takesARef"
+			end.type.arg_types.to_a[1]
+			expect(ref_type.kind).to eq(:type_rvalue_ref)
+			
+			intrinsic = ref_type.intrinsic_type
+			expect(intrinsic.kind).to eq(:type_float)
+		end
+		
+		it "follows a single pointer and drops cv-qualifiers" do
+			# const_int_ptr is `int const *`; intrinsic_type should yield `int`.
+			ptr_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_typedef_decl and child.spelling == "const_int_ptr"
+			end.type.canonical
+			expect(ptr_type.kind).to eq(:type_pointer)
+			
+			intrinsic = ptr_type.intrinsic_type
+			expect(intrinsic.kind).to eq(:type_int)
+			expect(intrinsic.const_qualified?).to be false
+		end
+		
+		it "follows a pointer-to-pointer chain" do
+			# int_pp is `int **`; intrinsic_type should yield `int`.
+			pp_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_typedef_decl and child.spelling == "int_pp"
+			end.type.canonical
+			expect(pp_type.kind).to eq(:type_pointer)
+			
+			intrinsic = pp_type.intrinsic_type
+			expect(intrinsic.kind).to eq(:type_int)
+		end
+		
+		it "strips a reference to a pointer" do
+			# takesPtrRefs(int*& pRef, ...) — first arg is `int *&`.
+			arg_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_function and child.spelling == "takesPtrRefs"
+			end.type.arg_types.to_a[0]
+			expect(arg_type.kind).to eq(:type_lvalue_ref)
+			
+			intrinsic = arg_type.intrinsic_type
+			expect(intrinsic.kind).to eq(:type_int)
+		end
+		
+		it "strips a reference to a pointer-to-pointer" do
+			# takesPtrRefs(..., int**& ppRef) — second arg is `int **&`.
+			arg_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_function and child.spelling == "takesPtrRefs"
+			end.type.arg_types.to_a[1]
+			expect(arg_type.kind).to eq(:type_lvalue_ref)
+			
+			intrinsic = arg_type.intrinsic_type
+			expect(intrinsic.kind).to eq(:type_int)
+		end
+		
+		it "returns the unchanged kind for a fundamental type" do
+			int_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_field_decl and child.spelling == "int_member_a"
+			end.type
+			expect(int_type.kind).to eq(:type_int)
+			expect(int_type.intrinsic_type.kind).to eq(:type_int)
+		end
+		
+		it "returns an invalid type without crashing on a type_invalid input" do
+			invalid_cxtype = FFI::Clang::Lib::CXType.new
+			invalid_type = FFI::Clang::Types::Type.new(invalid_cxtype, nil)
+			expect(invalid_type.kind).to eq(:type_invalid)
+			
+			result = invalid_type.intrinsic_type
+			expect(result.kind).to eq(:type_invalid)
+		end
+	end
+	
 	describe "#const_qualified?" do
 		let(:pointer_type) do
 			find_matching(cursor_cxx) do |child, parent|


### PR DESCRIPTION
## Types of Changes

- New feature.

## Description

Adds a new `Type#intrinsic_type` method that strips reference, follows pointer indirection, and drops cv-qualifiers — the same shape as Rice's `intrinsic_type` metafunction. Composes the existing `non_reference_type` / `pointee` / `unqualified_type` walkers (all of which were recently hardened against `type_invalid` input in #132 / #133), so this method is safe on invalid types too.

## Why

Wrapping libraries that compose libclang type queries (e.g., [ruby-bindgen](https://github.com/ruby-rice/ruby-bindgen)) frequently want to ask "what does this type ultimately denote?" — strip references, walk pointers, drop cv-qualifiers — without dispatching on every reference/pointer/cv combination. ruby-bindgen has been carrying this exact method as a refinement on `Type`; lifting it into ffi-clang makes it available to everyone and removes the duplication.

## Examples

| Input         | `intrinsic_type` |
| ------------- | ---------------- |
| `T &`         | `T`              |
| `T *`         | `T`              |
| `T **`        | `T`              |
| `T *&`        | `T`              |
| `T **&`       | `T`              |
| `const T *`   | `T`              |
| `const T &`   | `T`              |
| `int` (fundamental) | `int`     |
| `:type_invalid`     | `:type_invalid` (no crash, by virtue of the underlying guards) |

## Tests

Eight new examples in `spec/ffi/clang/type_spec.rb` under `describe \"#intrinsic_type\"`, plus two small fixture additions to `spec/ffi/clang/fixtures/test.cxx` (`typedef int** int_pp;` and `void takesPtrRefs(int*& pRef, int**& ppRef);`).

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).