### PR TITLE
Add Type#reference? predicate

### DIFF
--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -138,6 +138,12 @@ module FFI
 					Type.create Lib.get_unqualified_type(@type), @translation_unit
 				end
 				
+				# True if this type is an lvalue or rvalue reference.
+				# @returns [Boolean] Whether this type is `T &` or `T &&`.
+				def reference?
+					self.kind == :type_lvalue_ref || self.kind == :type_rvalue_ref
+				end
+				
 				# Get the non-reference type.
 				# For reference types, returns the type that is being referenced.
 				# @returns [Type] The non-reference type.

--- a/spec/ffi/clang/type_spec.rb
+++ b/spec/ffi/clang/type_spec.rb
@@ -142,6 +142,39 @@ describe FFI::Clang::Types::Type do
 		end
 	end
 	
+	describe "#reference?" do
+		it "returns true for an lvalue reference" do
+			ref_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_cxx_method and child.spelling == "takesARef"
+			end.type.arg_types.to_a[0]
+			expect(ref_type.kind).to eq(:type_lvalue_ref)
+			expect(ref_type.reference?).to be true
+		end
+		
+		it "returns true for an rvalue reference" do
+			ref_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_cxx_method and child.spelling == "takesARef"
+			end.type.arg_types.to_a[1]
+			expect(ref_type.kind).to eq(:type_rvalue_ref)
+			expect(ref_type.reference?).to be true
+		end
+		
+		it "returns false for a non-reference type" do
+			int_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_field_decl and child.spelling == "int_member_a"
+			end.type
+			expect(int_type.reference?).to be false
+		end
+		
+		it "returns false for a pointer type" do
+			ptr_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_typedef_decl and child.spelling == "const_int_ptr"
+			end.type.canonical
+			expect(ptr_type.kind).to eq(:type_pointer)
+			expect(ptr_type.reference?).to be false
+		end
+	end
+	
 	describe "#non_reference_type" do
 		# clang_getNonReferenceType dereferences the underlying QualType
 		# without a null check, so calling it on CXType_Invalid segfaults


### PR DESCRIPTION
## Summary
- Adds `FFI::Clang::Types::Type#reference?` returning true for `:type_lvalue_ref` and `:type_rvalue_ref`.
- Trivial wrapper, but pairs with the existing `non_reference_type` unwrap and removes the need to repeat the kind check at every callsite that wants to ask "is this a reference?" before deciding whether to unwrap.

## Test plan
- [x] `rspec spec/ffi/clang/type_spec.rb -e "reference?"` — 4 examples (lvalue ref, rvalue ref, non-reference type, pointer type)
- [x] Full `rspec spec/ffi/clang/type_spec.rb` passes (86 examples)
- [x] `rubocop lib/ffi/clang/types/type.rb spec/ffi/clang/type_spec.rb` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)