### PR TITLE
Add Cursor#copy_assignable? and Type#copy_assignable?

### DIFF
--- a/lib/ffi/clang/cursor.rb
+++ b/lib/ffi/clang/cursor.rb
@@ -814,9 +814,9 @@ module FFI
 			end
 			
 			# Check if this class/struct is copyable: it has no inaccessible
-			# (deleted or private) copy constructor, and every base class is
-			# copyable (recursively). Returns true on cursors that don't denote
-			# a class/struct, since the question doesn't apply.
+			# (deleted, private, or protected) copy constructor, and every base
+			# class is copyable (recursively). Returns true on cursors that
+			# don't denote a class/struct, since the question doesn't apply.
 			#
 			# A class with no explicit copy constructor is treated as copyable —
 			# the implicit one is generated. We only flag explicit `= delete` or
@@ -828,13 +828,41 @@ module FFI
 				
 				copy_constructors = self.find_by_kind(false, :cursor_constructor).select(&:copy_constructor?)
 				copy_constructors.each do |constructor|
-					return false if constructor.deleted? || constructor.private?
+					return false if constructor.deleted? || constructor.private? || constructor.protected?
 				end
 				
 				self.find_by_kind(false, :cursor_cxx_base_specifier).each do |base|
 					base_decl = base.type.declaration
 					next if base_decl.kind == :cursor_no_decl_found
 					return false unless base_decl.copyable?
+				end
+				
+				true
+			end
+			
+			# Check if this class/struct is copy-assignable: it has no
+			# inaccessible (deleted, private, or protected) copy assignment
+			# operator, and every base class is copy-assignable (recursively).
+			# Returns true on cursors that don't denote a class/struct, since
+			# the question doesn't apply.
+			#
+			# A class with no explicit copy assignment operator is treated as
+			# copy-assignable — the implicit one is generated. We only flag
+			# explicit `= delete` or private/protected access.
+			#
+			# @returns [Boolean] True if instances of this type can be copy-assigned.
+			def copy_assignable?
+				return true unless [:cursor_class_decl, :cursor_struct].include?(self.kind)
+				
+				copy_assignment_operators = self.find_by_kind(false, :cursor_cxx_method).select(&:copy_assignment_operator?)
+				copy_assignment_operators.each do |operator|
+					return false if operator.deleted? || operator.private? || operator.protected?
+				end
+				
+				self.find_by_kind(false, :cursor_cxx_base_specifier).each do |base|
+					base_decl = base.type.declaration
+					next if base_decl.kind == :cursor_no_decl_found
+					return false unless base_decl.copy_assignable?
 				end
 				
 				true

--- a/lib/ffi/clang/types/type.rb
+++ b/lib/ffi/clang/types/type.rb
@@ -189,6 +189,17 @@ module FFI
 					self.non_reference_type.declaration.copyable?
 				end
 				
+				# Check if this type's declaration (after reference stripping)
+				# has an accessible copy assignment operator and copy-assignable
+				# bases. Returns true for non-class types (fundamentals, pointers,
+				# enums) and for types whose declaration is unavailable
+				# (:cursor_no_decl_found).
+				#
+				# @returns [Boolean] True if instances of this type can be copy-assigned.
+				def copy_assignable?
+					self.non_reference_type.declaration.copy_assignable?
+				end
+				
 				# Get the type of a template argument at the given index.
 				# For template specializations (e.g., `std::vector<int>`), this returns the type of
 				# the template argument at the specified position.

--- a/spec/ffi/clang/cursor_spec.rb
+++ b/spec/ffi/clang/cursor_spec.rb
@@ -1488,6 +1488,12 @@ describe FFI::Clang::Cursor do
 			end
 		end
 		
+		let(:protected_copy) do
+			find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_class_decl and child.spelling == "ProtectedCopy"
+			end
+		end
+		
 		it "returns true for a struct with implicit copy constructor" do
 			expect(simple_struct.copyable?).to be true
 		end
@@ -1500,6 +1506,10 @@ describe FFI::Clang::Cursor do
 			expect(private_copy.copyable?).to be false
 		end
 		
+		it "returns false for a class with protected copy constructor" do
+			expect(protected_copy.copyable?).to be false
+		end
+		
 		it "returns false transitively when a base class is not copyable" do
 			expect(inherits_deleted_copy.copyable?).to be false
 		end
@@ -1509,6 +1519,65 @@ describe FFI::Clang::Cursor do
 				child.kind == :cursor_function and child.spelling == "binary_operator_func"
 			end
 			expect(func.copyable?).to be true
+		end
+	end
+	
+	describe "#copy_assignable?" do
+		let(:simple_struct) do
+			find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_struct and child.spelling == "SimpleStruct"
+			end
+		end
+		
+		let(:deleted_assign) do
+			find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_struct and child.spelling == "DeletedAssign"
+			end
+		end
+		
+		let(:private_assign) do
+			find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_class_decl and child.spelling == "PrivateAssign"
+			end
+		end
+		
+		let(:protected_assign) do
+			find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_class_decl and child.spelling == "ProtectedAssign"
+			end
+		end
+		
+		let(:inherits_deleted_assign) do
+			find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_struct and child.spelling == "InheritsDeletedAssign"
+			end
+		end
+		
+		it "returns true for a struct with implicit copy assignment operator" do
+			expect(simple_struct.copy_assignable?).to be true
+		end
+		
+		it "returns false for a struct with deleted copy assignment operator" do
+			expect(deleted_assign.copy_assignable?).to be false
+		end
+		
+		it "returns false for a class with private copy assignment operator" do
+			expect(private_assign.copy_assignable?).to be false
+		end
+		
+		it "returns false for a class with protected copy assignment operator" do
+			expect(protected_assign.copy_assignable?).to be false
+		end
+		
+		it "returns false transitively when a base class is not copy-assignable" do
+			expect(inherits_deleted_assign.copy_assignable?).to be false
+		end
+		
+		it "returns true on a non-class cursor" do
+			func = find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_function and child.spelling == "binary_operator_func"
+			end
+			expect(func.copy_assignable?).to be true
 		end
 	end
 	

--- a/spec/ffi/clang/fixtures/types.cxx
+++ b/spec/ffi/clang/fixtures/types.cxx
@@ -62,6 +62,42 @@ struct InheritsDeletedCopy : public DeletedCopy {
 	int value;
 };
 
+// Protected copy constructor — not copyable from external code.
+class ProtectedCopy {
+protected:
+	ProtectedCopy(const ProtectedCopy&);
+public:
+	ProtectedCopy();
+};
+
+// Deleted copy assignment operator — not copy-assignable.
+struct DeletedAssign {
+	DeletedAssign() = default;
+	DeletedAssign(const DeletedAssign&) = default;
+	DeletedAssign& operator=(const DeletedAssign&) = delete;
+};
+
+// Private copy assignment operator — not copy-assignable.
+class PrivateAssign {
+public:
+	PrivateAssign();
+private:
+	PrivateAssign& operator=(const PrivateAssign&);
+};
+
+// Protected copy assignment operator — not copy-assignable from external code.
+class ProtectedAssign {
+public:
+	ProtectedAssign() = default;
+protected:
+	ProtectedAssign& operator=(const ProtectedAssign&) = default;
+};
+
+// Inherits from a non-copy-assignable base — not transitively copy-assignable.
+struct InheritsDeletedAssign : public DeletedAssign {
+	int value;
+};
+
 // Explicit constructor
 struct ExplicitCtor {
 	explicit ExplicitCtor(int x);

--- a/spec/ffi/clang/type_spec.rb
+++ b/spec/ffi/clang/type_spec.rb
@@ -350,6 +350,38 @@ describe FFI::Clang::Types::Type do
 		end
 	end
 	
+	describe "#copy_assignable?" do
+		let(:cursor_types) {Index.new.parse_translation_unit(fixture_path("types.cxx")).cursor}
+		
+		it "returns true for a copy-assignable struct type" do
+			type = find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_struct and child.spelling == "SimpleStruct"
+			end.type
+			expect(type.copy_assignable?).to be true
+		end
+		
+		it "returns false for a struct type with deleted copy assignment operator" do
+			type = find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_struct and child.spelling == "DeletedAssign"
+			end.type
+			expect(type.copy_assignable?).to be false
+		end
+		
+		it "returns false for a class type with protected copy assignment operator" do
+			type = find_matching(cursor_types) do |child, parent|
+				child.kind == :cursor_class_decl and child.spelling == "ProtectedAssign"
+			end.type
+			expect(type.copy_assignable?).to be false
+		end
+		
+		it "returns true for a fundamental type" do
+			int_type = find_matching(cursor_cxx) do |child, parent|
+				child.kind == :cursor_field_decl and child.spelling == "int_member_a"
+			end.type
+			expect(int_type.copy_assignable?).to be true
+		end
+	end
+	
 	describe "#const_qualified?" do
 		let(:pointer_type) do
 			find_matching(cursor_cxx) do |child, parent|


### PR DESCRIPTION
## Types of Changes

- New feature.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

## Summary

`Cursor#copy_assignable?` returns true when a class/struct cursor has an accessible copy assignment operator (none deleted, private, or protected) and every base class is copy-assignable. Mirrors the existing `Cursor#copyable?` shape, but uses `copy_assignment_operator?` to filter cursor methods. Returns true for non-class cursors so callers can ask uniformly without dispatching on kind.

`Type#copy_assignable?` wraps the cursor predicate, stripping references first.

This pairs with the existing `Cursor#copy_constructor?`, `#copy_assignment_operator?`, `#deleted?`, `#private?`, and `#protected?` predicates already in ffi-clang. Useful for binding-generation tools deciding whether a field is read/write or read-only — a class with a protected or deleted `operator=` cannot be assigned by external code, so its fields must be exposed as read-only.

### Behavior tweak to `#copyable?`

This PR also tightens `Cursor#copyable?` to flag protected copy constructors. The method's existing docstring says "private/protected access" but the implementation only checked `private?`. Protected copy semantics are equivalent to private for external callers — neither is invocable from outside the class hierarchy — which is the question binding generators are asking.

A new spec case (`ProtectedCopy`) locks in the new behavior.